### PR TITLE
Switch from Terraform to OpenTofu 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Terragrunt Concourse Resource
 
-> **This is an adaptation of the [terraform-resource](https://github.com/ljfranklin/terraform-resource) to work with [Terragrunt](https://terragrunt.gruntwork.io/) configurations.**
+> **This is an adaptation of the [terraform-resource](https://github.com/ljfranklin/terraform-resource) to work with [OpenTofu](https://opentofu.org/) and [Terragrunt](https://terragrunt.gruntwork.io/) configurations.**
 > All configuration remains the same.
 
 A [Concourse](http://concourse-ci.org/) resource that allows jobs to modify IaaS resources via [Terraform](https://www.terraform.io/).

--- a/ci/pipeline-terragrunt.yml
+++ b/ci/pipeline-terragrunt.yml
@@ -28,7 +28,7 @@ jobs:
               globs:
                 - terragrunt_linux_amd64
                 - terragrunt_linux_arm64
-          - get: terraform-release
+          - get: opentofu-release
             trigger: true
       - in_parallel:
           - task: write-docker-metadata-files
@@ -42,7 +42,7 @@ jobs:
                   password: ((DOCKER_HUB_SKYSCRAPERS_CREDS.password))
               inputs:
                 - name: resource-src
-                - name: terraform-release
+                - name: opentofu-release
                 - name: terragrunt-release
               outputs:
                 - name: docker-metadata
@@ -51,13 +51,13 @@ jobs:
                 args:
                   - "-c"
                   - |
-                    TF_VERSION="$(cat terraform-release/tag)"
+                    TF_VERSION="$(cat opentofu-release/tag)"
                     TF_VERSION="${TF_VERSION:1}" # Trim trailing v from tag
                     TG_VERSION="$(cat terragrunt-release/tag)"
                     TG_VERSION="${TG_VERSION:1}" # Trim trailing v from tag
                     SHA="$(cat resource-src/.git/short_ref)"
                     echo "${TF_VERSION} ${TF_VERSION}-${SHA} ${TF_VERSION}-${TG_VERSION}" > docker-metadata/tags
-                    echo "{\"terraform_version\": \"${TF_VERSION}\", \"terragrunt_version\": \"${TG_VERSION}\"}" > docker-metadata/labels
+                    echo "{\"opentofu_version\": \"${TF_VERSION}\", \"terragrunt_version\": \"${TG_VERSION}\"}" > docker-metadata/labels
           - task: build-artifacts
             file: resource-src/ci/tasks/build-prod-artifacts.yml
       - put: terragrunt-resource-image
@@ -97,13 +97,13 @@ resources:
       owner: gruntwork-io
       repository: terragrunt
       access_token: ((GITHUB_REPO_ACCESS_TOKEN_SKY_TECH))
-  - name: terraform-release
+  - name: opentofu-release
     type: github-release
     check_every: 24h
     icon: github
     source:
-      user: hashicorp
-      repository: terraform
+      user: opentofu
+      repository: opentofu
       access_token: ((GITHUB_REPO_ACCESS_TOKEN_SKY_TECH))
   - name: terragrunt-resource-image
     type: docker-buildx

--- a/ci/tasks/build-prod-artifacts.yml
+++ b/ci/tasks/build-prod-artifacts.yml
@@ -9,7 +9,7 @@ image_resource:
 
 inputs:
   - name: resource-src
-  - name: terraform-release
+  - name: opentofu-release
     optional: true
   - name: terragrunt-release
     optional: true
@@ -23,4 +23,4 @@ run:
 params:
   DOCKERFILE_DIR: "resource-src/docker-prod/"
   TERRAGRUNT_RELEASE_DIR: "terragrunt-release"
-  TERRAFORM_RELEASE_DIR: "terraform-release"
+  TERRAFORM_RELEASE_DIR: "opentofu-release"

--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -53,5 +53,5 @@ RUN mkdir -p /usr/local/share/terraform/plugins/github.com/ashald/stateful/1.2.0
   "https://github.com/ashald/terraform-provider-stateful/releases/download/v1.2.0/terraform-provider-stateful_v1.2.0-linux-${TARGETARCH}" && \
   chmod +x /usr/local/share/terraform/plugins/github.com/ashald/stateful/1.2.0/linux_${TARGETARCH}/terraform-provider-stateful_v1.2.0
 COPY $TARGETARCH/terraform/* /usr/local/bin/
-RUN terraform --version
+RUN tofu --version
 COPY $TARGETARCH/check $TARGETARCH/in $TARGETARCH/out /opt/resource/

--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:latest
 
 ARG TARGETARCH
-ARG AWSCLI_VERSION=2.9.18
+ARG AWSCLI_VERSION=2.15.48
 
 RUN apk update && \
-    apk add ca-certificates git bash openssh-client curl
+  apk add ca-certificates git bash openssh-client curl
 
 # this glibc compatibility module is needed for some downloaded binaries,
 # such as aws cli, to run in provisioners.
@@ -15,30 +15,30 @@ RUN apk update && \
 # TODO: Remove --force-overwrite once
 # https://github.com/sgerrand/alpine-pkg-glibc/issues/185 is fixed
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget -q -O /tmp/glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk && \
-    wget -q -O /tmp/glibc-bin.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-bin-2.32-r0.apk; \
+  wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+  wget -q -O /tmp/glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk && \
+  wget -q -O /tmp/glibc-bin.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-bin-2.32-r0.apk; \
   elif [ "${TARGETARCH}" = "arm64" ]; then \
-    wget -q -O /etc/apk/keys/ljfranklin-glibc.pub https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/ljfranklin-glibc.pub && \
-    wget -q -O /tmp/glibc.apk https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/glibc-2.32-r0.apk && \
-    wget -q -O /tmp/glibc-bin.apk https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/glibc-bin-2.32-r0.apk; \
+  wget -q -O /etc/apk/keys/ljfranklin-glibc.pub https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/ljfranklin-glibc.pub && \
+  wget -q -O /tmp/glibc.apk https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/glibc-2.32-r0.apk && \
+  wget -q -O /tmp/glibc-bin.apk https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/glibc-bin-2.32-r0.apk; \
   fi; \
   apk add --force-overwrite /tmp/glibc.apk && \
   apk add /tmp/glibc-bin.apk && \
   # Install awscli
   if [ "${TARGETARCH}" = "amd64" ]; then \
-    curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip -o awscliv2.zip; \
+  curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip -o awscliv2.zip; \
   elif [ "${TARGETARCH}" = "arm64" ]; then \
-    curl -sL https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWSCLI_VERSION}.zip -o awscliv2.zip; \
+  curl -sL https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWSCLI_VERSION}.zip -o awscliv2.zip; \
   fi; \
   unzip awscliv2.zip && \
   aws/install && \
   rm -rf \
-    awscliv2.zip \
-    aws \
-    /usr/local/aws-cli/v2/current/dist/aws_completer \
-    /usr/local/aws-cli/v2/current/dist/awscli/data/ac.index \
-    /usr/local/aws-cli/v2/current/dist/awscli/examples && \
+  awscliv2.zip \
+  aws \
+  /usr/local/aws-cli/v2/current/dist/aws_completer \
+  /usr/local/aws-cli/v2/current/dist/awscli/data/ac.index \
+  /usr/local/aws-cli/v2/current/dist/awscli/examples && \
   find /usr/local/aws-cli/v2/current/dist/awscli/botocore/data -name examples-1.json -delete && \
   rm -rf /tmp/glibc.apk && \
   rm -rf /tmp/glibc-bin.apk
@@ -50,7 +50,7 @@ RUN chmod 0600 $HOME/.ssh/config
 
 RUN mkdir -p /usr/local/share/terraform/plugins/github.com/ashald/stateful/1.2.0/linux_${TARGETARCH}/ && \
   wget -O /usr/local/share/terraform/plugins/github.com/ashald/stateful/1.2.0/linux_${TARGETARCH}/terraform-provider-stateful_v1.2.0 \
-    "https://github.com/ashald/terraform-provider-stateful/releases/download/v1.2.0/terraform-provider-stateful_v1.2.0-linux-${TARGETARCH}" && \
+  "https://github.com/ashald/terraform-provider-stateful/releases/download/v1.2.0/terraform-provider-stateful_v1.2.0-linux-${TARGETARCH}" && \
   chmod +x /usr/local/share/terraform/plugins/github.com/ashald/stateful/1.2.0/linux_${TARGETARCH}/terraform-provider-stateful_v1.2.0
 COPY $TARGETARCH/terraform/* /usr/local/bin/
 RUN terraform --version

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -17,7 +17,7 @@ USAGE:
     $0 <MANDATORY ARGUMENTS> [OPTIONAL ARGUMENTS]
 MANDATORY ARGUMENTS:
     --image-name <name>        Name of the Docker image you'd like to build, e.g. ljfranklin/terraform-resource:PR-test
-    --terraform-url <url>      URL of the terraform release you'd like to include, e.g. https://releases.hashicorp.com/terraform/0.9.3/terraform_0.9.3_linux_amd64.zip
+    --opentofu-url <url>       URL of the opentofu release you'd like to include, e.g. https://github.com/opentofu/opentofu/releases/download/v1.7.1/tofu_1.7.1_linux_amd64.zip
     --terragrunt-url <url>      URL of the terragrunt release you'd like to include, e.g. https://github.com/gruntwork-io/terragrunt/releases/download/v0.43.0/terragrunt_linux_amd64
     --target-arch <arch>       Architecture to build the image for e.g. amd64 or arm64
 OPTIONAL ARGUMENTS:
@@ -48,12 +48,12 @@ while true ; do
       image_name="$2"
       shift 2
       ;;
-    --terraform-url)
+    --opentofu-url)
       if [ -z "$2" ]; then
-        >&2 echo -e "${red}--terraform-url requires an argument!${nc}"
+        >&2 echo -e "${red}--opentofu-url requires an argument!${nc}"
         exit 1
       fi
-      terraform_url="$2"
+      opentofu_url="$2"
       shift 2
       ;;
     --terragrunt-url)
@@ -87,8 +87,8 @@ if [ -z "${image_name}" ]; then
   >&2 echo -e "${red}Missing required flag --image-name <name>!${nc}"
   usage
 fi
-if [ -z "${terraform_url}" ]; then
-  >&2 echo -e "${red}Missing required flag --terraform-url <url>!${nc}"
+if [ -z "${opentofu_url}" ]; then
+  >&2 echo -e "${red}Missing required flag --opentofu-url <url>!${nc}"
   usage
 fi
 if [ -z "${terragrunt_url}" ]; then
@@ -101,16 +101,16 @@ trap "{ rm -rf ${tmpdir}; }" EXIT
 
 pushd "${tmpdir}" > /dev/null
 
-  echo "Downloading terraform from '${terraform_url}'..."
-  wget -q -O terraform.zip "${terraform_url}"
-  mkdir -p ./amd64/terraform
-  unzip -d ./amd64/terraform terraform.zip > /dev/null
+  echo "Downloading OpenTofu from '${opentofu_url}'..."
+  wget -q -O opentofu.zip "${opentofu_url}"
+  mkdir -p ./amd64/terraform/opentofu
+  unzip -d ./amd64/terraform/opentofu opentofu.zip > /dev/null
 
   echo "Downloading terragrunt from '${terragrunt_url}'..."
   wget -q -O ./amd64/terraform/terragrunt "${terragrunt_url}"
   chmod +x ./amd64/terraform/terragrunt
 
-  echo "Compiling terraform-resource binaries..."
+  echo "Compiling terragrunt-resource binaries..."
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 "${release_dir}/scripts/build" "$PWD/amd64" > /dev/null
 
   echo "Building docker image '${image_name}'..."


### PR DESCRIPTION
per skyscrapers/platform#1174

This PR modifies the build steps to download OpenTofu instead of Terraform.