### PR TITLE
feat: Add web_identity_token/role_arn for keyless OIDC auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ See [Terraform Input Variables](https://www.terraform.io/language/values/variabl
 
 * `private_key`: *Optional.* An SSH key used to fetch modules, e.g. [private GitHub repos](https://www.terraform.io/docs/modules/sources.html#private-github-repos).
 
+* `web_identity_token`: *Optional.* An OIDC token (JWT) used for keyless AWS authentication. When set together with `role_arn`, the resource writes the token to a 0600 file and exports `AWS_WEB_IDENTITY_TOKEN_FILE` (and `AWS_ROLE_ARN`) for every `tofu`/`terragrunt`/`aws` invocation. The AWS SDK default credential chain then assumes the role via `AssumeRoleWithWebIdentity`, so terraform/tofu, the AWS provider, and CLI tools like `aws eks get-token` all pick up the web-identity credentials with no static access key. Backward-compatible: omit both fields to keep using static keys via `env` (e.g. `AWS_ACCESS_KEY_ID`).
+
+* `role_arn`: *Optional.* The ARN of the AWS IAM role to assume via web identity. Used together with `web_identity_token`; sets `AWS_ROLE_ARN`. Has no effect unless `web_identity_token` is also set.
+
 #### Source Example
 
 ```yaml

--- a/src/terraform-resource/models/terraform.go
+++ b/src/terraform-resource/models/terraform.go
@@ -27,15 +27,17 @@ type Terraform struct {
 	Parallelism           int                    `json:"parallelism,omitempty"`           // optional
 	LockTimeout           string                 `json:"lock_timeout,omitempty"`          // optional
 	PrivateKey            string                 `json:"private_key,omitempty"`
-	PlanFileLocalPath     string                 `json:"-"` // not specified pipeline
-	JSONPlanFileLocalPath string                 `json:"-"` // not specified pipeline
-	PlanFileRemotePath    string                 `json:"-"` // not specified pipeline
-	StateFileLocalPath    string                 `json:"-"` // not specified pipeline
-	StateFileRemotePath   string                 `json:"-"` // not specified pipeline
-	Imports               map[string]string      `json:"-"` // not specified pipeline
-	ConvertedVarFiles     []string               `json:"-"` // not specified pipeline
-	DownloadPlugins       bool                   `json:"-"` // not specified pipeline
-	Terragrunt            bool                   `json:"-"` // not specified pipeline
+	WebIdentityToken      string                 `json:"web_identity_token,omitempty"` // optional
+	RoleArn               string                 `json:"role_arn,omitempty"`           // optional
+	PlanFileLocalPath     string                 `json:"-"`                            // not specified pipeline
+	JSONPlanFileLocalPath string                 `json:"-"`                            // not specified pipeline
+	PlanFileRemotePath    string                 `json:"-"`                            // not specified pipeline
+	StateFileLocalPath    string                 `json:"-"`                            // not specified pipeline
+	StateFileRemotePath   string                 `json:"-"`                            // not specified pipeline
+	Imports               map[string]string      `json:"-"`                            // not specified pipeline
+	ConvertedVarFiles     []string               `json:"-"`                            // not specified pipeline
+	DownloadPlugins       bool                   `json:"-"`                            // not specified pipeline
+	Terragrunt            bool                   `json:"-"`                            // not specified pipeline
 }
 
 const (
@@ -96,6 +98,14 @@ func (m Terraform) Merge(other Terraform) Terraform {
 
 	if other.PrivateKey != "" {
 		m.PrivateKey = other.PrivateKey
+	}
+
+	if other.WebIdentityToken != "" {
+		m.WebIdentityToken = other.WebIdentityToken
+	}
+
+	if other.RoleArn != "" {
+		m.RoleArn = other.RoleArn
 	}
 
 	if other.PlanOnly {

--- a/src/terraform-resource/models/terraform_test.go
+++ b/src/terraform-resource/models/terraform_test.go
@@ -220,6 +220,35 @@ some_hcl_key = "some_hcl_value"
 			Expect(finalModel.PrivateKey).To(Equal("fake-merged-key"))
 		})
 	})
+
+	Describe("WebIdentityToken and RoleArn", func() {
+		It("returns the values from original", func() {
+			baseModel := models.Terraform{
+				WebIdentityToken: "fake-token",
+				RoleArn:          "fake-role-arn",
+			}
+			mergeModel := models.Terraform{}
+
+			finalModel := baseModel.Merge(mergeModel)
+			Expect(finalModel.WebIdentityToken).To(Equal("fake-token"))
+			Expect(finalModel.RoleArn).To(Equal("fake-role-arn"))
+		})
+
+		It("returns the values from merged", func() {
+			baseModel := models.Terraform{
+				WebIdentityToken: "fake-token",
+				RoleArn:          "fake-role-arn",
+			}
+			mergeModel := models.Terraform{
+				WebIdentityToken: "fake-merged-token",
+				RoleArn:          "fake-merged-role-arn",
+			}
+
+			finalModel := baseModel.Merge(mergeModel)
+			Expect(finalModel.WebIdentityToken).To(Equal("fake-merged-token"))
+			Expect(finalModel.RoleArn).To(Equal("fake-merged-role-arn"))
+		})
+	})
 })
 
 func writeToTempFile(tmpDir string, contents string, ext string) string {

--- a/src/terraform-resource/terraform/client.go
+++ b/src/terraform-resource/terraform/client.go
@@ -53,6 +53,7 @@ type client struct {
 	model                models.Terraform
 	logWriter            io.Writer
 	terragruntWorkingDir string
+	webIdentityTokenFile string
 }
 
 type StateVersion struct {
@@ -993,5 +994,45 @@ func (c *client) terraformCmd(args []string, env []string) (*runner.Runner, erro
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
+	// When both web_identity_token and role_arn are set, materialise the token
+	// to a file and export the standard AWS SDK web-identity env vars. The AWS
+	// SDK default credential chain (used by tofu/terragrunt, the AWS provider,
+	// and CLI tools like `aws eks get-token`) then assumes the role via
+	// AssumeRoleWithWebIdentity. Opt-in and backward-compatible: when the fields
+	// are absent, static-key Env passthrough (AWS_ACCESS_KEY_ID, ...) is unchanged.
+	if c.model.WebIdentityToken != "" && c.model.RoleArn != "" {
+		tokenFile, err := c.webIdentityTokenFilePath()
+		if err != nil {
+			return nil, err
+		}
+		cmd.Env = append(cmd.Env, fmt.Sprintf("AWS_ROLE_ARN=%s", c.model.RoleArn))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("AWS_WEB_IDENTITY_TOKEN_FILE=%s", tokenFile))
+	}
+
 	return runner.New(cmd, c.logWriter), nil
+}
+
+// webIdentityTokenFilePath writes the OIDC web-identity token to a 0600 file
+// once and caches the path on the client, so subsequent terraform/aws calls
+// reuse the same file. The token value itself is never logged.
+func (c *client) webIdentityTokenFilePath() (string, error) {
+	if c.webIdentityTokenFile != "" {
+		return c.webIdentityTokenFile, nil
+	}
+
+	tokenFile, err := ioutil.TempFile("", "aws-web-identity-token-*")
+	if err != nil {
+		return "", err
+	}
+	defer tokenFile.Close()
+
+	if err := tokenFile.Chmod(0600); err != nil {
+		return "", err
+	}
+	if _, err := tokenFile.WriteString(c.model.WebIdentityToken); err != nil {
+		return "", err
+	}
+
+	c.webIdentityTokenFile = tokenFile.Name()
+	return c.webIdentityTokenFile, nil
 }


### PR DESCRIPTION
# Description

Adds OIDC web-identity (keyless) AWS authentication to the resource, so CI can run terragrunt/tofu without a static AWS access key. This is the resource-side change for keyless Concourse CI in skyscrapers/platform#2088 (the `idtoken` var source mints a per-pipeline JWT; the resource turns that JWT into AWS credentials via the SDK default chain).

## What changed (contract)

- Two new optional `source` fields on the `Terraform` model (`src/terraform-resource/models/terraform.go`):
  - `web_identity_token` -> `WebIdentityToken string` (the OIDC JWT)
  - `role_arn` -> `RoleArn string` (the IAM role to assume)
  - Both merged in `Merge(other)` following the existing scalar-string pattern (same as `PrivateKey`).
- Behaviour (`src/terraform-resource/terraform/client.go`): when **both** fields are non-empty, `terraformCmd` (the single chokepoint that builds `cmd.Env` for every `init`/`plan`/`apply`/`output`/`terragrunt-info` invocation, plus any `aws` call the binaries make) appends:
  - `AWS_ROLE_ARN=<RoleArn>`
  - `AWS_WEB_IDENTITY_TOKEN_FILE=<path to a 0600 file holding the token>`
  - The token file is materialised lazily and cached on the client (`webIdentityTokenFile`), so it is written **once**, not per call. The token value is never logged.
- The AWS SDK default credential chain then assumes the role via `AssumeRoleWithWebIdentity`. This works uniformly for tofu/terragrunt, the AWS provider, and CLI tools the image ships (e.g. `aws eks get-token`, `kubectl` via the exec credential).

## Backward compatibility

Fully opt-in. When the fields are absent, nothing changes: the existing static-key flow (`env` passthrough of `AWS_ACCESS_KEY_ID` etc.) behaves exactly as before. No existing field, default, or code path is removed or altered.

## Testing

- `go build ./...` from `src/terraform-resource` (golang:1.17 container): passes.
- `go test ./models/...`: passes, including the new `WebIdentityToken and RoleArn` Merge test (mirrors the existing `PrivateKey` test).

## Image build / publishing note

No image is built or pushed in this PR (code only). For reference, a new image is published via the Concourse pipeline in `ci/build-image-pipeline.yml`: the `push-custom-image` job runs `ci/tasks/build-custom-artifacts.yml` to build the `check`/`in`/`out` Go binaries (multi-arch, `linux/amd64,linux/arm64`), then `put`s them to the `resource-custom-image` `docker-buildx` resource, which builds `docker-prod/Dockerfile` (alpine + aws-cli, kubectl, sops, tofu, the stateful provider, and the compiled resource binaries under `/opt/resource/`) and pushes to `((docker_repository)):((docker_tag))`. So merging this changes the source; an image carrying it only exists once that pipeline job runs and tags/pushes a new image.

# Related Issue

skyscrapers/platform#2088 (keyless CI via OIDC web identity).

# Checklist

- [x] I have followed the PR process as described [here](https://docs.skyscrapers.eu/docs/how-to-guides/coding_guidelines/git/#pull-requests)
- [ ] My code has been tested:
  - [x] Locally (`go build ./...` + `go test ./models/...` in golang:1.17; no Atlantis, this is a Go resource not IaC)
  - [ ] In this PR using Atlantis
- [ ] My code is ready to be applied.
  - [ ] contains breaking changes
