### PR TITLE
revert: Remove web_identity_token OIDC fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ See [Terraform Input Variables](https://www.terraform.io/language/values/variabl
 
 * `private_key`: *Optional.* An SSH key used to fetch modules, e.g. [private GitHub repos](https://www.terraform.io/docs/modules/sources.html#private-github-repos).
 
-* `web_identity_token`: *Optional.* An OIDC token (JWT) used for keyless AWS authentication. When set together with `role_arn`, the resource writes the token to a 0600 file and exports `AWS_WEB_IDENTITY_TOKEN_FILE` (and `AWS_ROLE_ARN`) for every `tofu`/`terragrunt`/`aws` invocation. The AWS SDK default credential chain then assumes the role via `AssumeRoleWithWebIdentity`, so terraform/tofu, the AWS provider, and CLI tools like `aws eks get-token` all pick up the web-identity credentials with no static access key. Backward-compatible: omit both fields to keep using static keys via `env` (e.g. `AWS_ACCESS_KEY_ID`).
-
-* `role_arn`: *Optional.* The ARN of the AWS IAM role to assume via web identity. Used together with `web_identity_token`; sets `AWS_ROLE_ARN`. Has no effect unless `web_identity_token` is also set.
-
 #### Source Example
 
 ```yaml

--- a/src/terraform-resource/models/terraform.go
+++ b/src/terraform-resource/models/terraform.go
@@ -27,17 +27,15 @@ type Terraform struct {
 	Parallelism           int                    `json:"parallelism,omitempty"`           // optional
 	LockTimeout           string                 `json:"lock_timeout,omitempty"`          // optional
 	PrivateKey            string                 `json:"private_key,omitempty"`
-	WebIdentityToken      string                 `json:"web_identity_token,omitempty"` // optional
-	RoleArn               string                 `json:"role_arn,omitempty"`           // optional
-	PlanFileLocalPath     string                 `json:"-"`                            // not specified pipeline
-	JSONPlanFileLocalPath string                 `json:"-"`                            // not specified pipeline
-	PlanFileRemotePath    string                 `json:"-"`                            // not specified pipeline
-	StateFileLocalPath    string                 `json:"-"`                            // not specified pipeline
-	StateFileRemotePath   string                 `json:"-"`                            // not specified pipeline
-	Imports               map[string]string      `json:"-"`                            // not specified pipeline
-	ConvertedVarFiles     []string               `json:"-"`                            // not specified pipeline
-	DownloadPlugins       bool                   `json:"-"`                            // not specified pipeline
-	Terragrunt            bool                   `json:"-"`                            // not specified pipeline
+	PlanFileLocalPath     string                 `json:"-"` // not specified pipeline
+	JSONPlanFileLocalPath string                 `json:"-"` // not specified pipeline
+	PlanFileRemotePath    string                 `json:"-"` // not specified pipeline
+	StateFileLocalPath    string                 `json:"-"` // not specified pipeline
+	StateFileRemotePath   string                 `json:"-"` // not specified pipeline
+	Imports               map[string]string      `json:"-"` // not specified pipeline
+	ConvertedVarFiles     []string               `json:"-"` // not specified pipeline
+	DownloadPlugins       bool                   `json:"-"` // not specified pipeline
+	Terragrunt            bool                   `json:"-"` // not specified pipeline
 }
 
 const (
@@ -98,14 +96,6 @@ func (m Terraform) Merge(other Terraform) Terraform {
 
 	if other.PrivateKey != "" {
 		m.PrivateKey = other.PrivateKey
-	}
-
-	if other.WebIdentityToken != "" {
-		m.WebIdentityToken = other.WebIdentityToken
-	}
-
-	if other.RoleArn != "" {
-		m.RoleArn = other.RoleArn
 	}
 
 	if other.PlanOnly {

--- a/src/terraform-resource/models/terraform_test.go
+++ b/src/terraform-resource/models/terraform_test.go
@@ -220,35 +220,6 @@ some_hcl_key = "some_hcl_value"
 			Expect(finalModel.PrivateKey).To(Equal("fake-merged-key"))
 		})
 	})
-
-	Describe("WebIdentityToken and RoleArn", func() {
-		It("returns the values from original", func() {
-			baseModel := models.Terraform{
-				WebIdentityToken: "fake-token",
-				RoleArn:          "fake-role-arn",
-			}
-			mergeModel := models.Terraform{}
-
-			finalModel := baseModel.Merge(mergeModel)
-			Expect(finalModel.WebIdentityToken).To(Equal("fake-token"))
-			Expect(finalModel.RoleArn).To(Equal("fake-role-arn"))
-		})
-
-		It("returns the values from merged", func() {
-			baseModel := models.Terraform{
-				WebIdentityToken: "fake-token",
-				RoleArn:          "fake-role-arn",
-			}
-			mergeModel := models.Terraform{
-				WebIdentityToken: "fake-merged-token",
-				RoleArn:          "fake-merged-role-arn",
-			}
-
-			finalModel := baseModel.Merge(mergeModel)
-			Expect(finalModel.WebIdentityToken).To(Equal("fake-merged-token"))
-			Expect(finalModel.RoleArn).To(Equal("fake-merged-role-arn"))
-		})
-	})
 })
 
 func writeToTempFile(tmpDir string, contents string, ext string) string {

--- a/src/terraform-resource/terraform/client.go
+++ b/src/terraform-resource/terraform/client.go
@@ -53,7 +53,6 @@ type client struct {
 	model                models.Terraform
 	logWriter            io.Writer
 	terragruntWorkingDir string
-	webIdentityTokenFile string
 }
 
 type StateVersion struct {
@@ -994,45 +993,5 @@ func (c *client) terraformCmd(args []string, env []string) (*runner.Runner, erro
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	// When both web_identity_token and role_arn are set, materialise the token
-	// to a file and export the standard AWS SDK web-identity env vars. The AWS
-	// SDK default credential chain (used by tofu/terragrunt, the AWS provider,
-	// and CLI tools like `aws eks get-token`) then assumes the role via
-	// AssumeRoleWithWebIdentity. Opt-in and backward-compatible: when the fields
-	// are absent, static-key Env passthrough (AWS_ACCESS_KEY_ID, ...) is unchanged.
-	if c.model.WebIdentityToken != "" && c.model.RoleArn != "" {
-		tokenFile, err := c.webIdentityTokenFilePath()
-		if err != nil {
-			return nil, err
-		}
-		cmd.Env = append(cmd.Env, fmt.Sprintf("AWS_ROLE_ARN=%s", c.model.RoleArn))
-		cmd.Env = append(cmd.Env, fmt.Sprintf("AWS_WEB_IDENTITY_TOKEN_FILE=%s", tokenFile))
-	}
-
 	return runner.New(cmd, c.logWriter), nil
-}
-
-// webIdentityTokenFilePath writes the OIDC web-identity token to a 0600 file
-// once and caches the path on the client, so subsequent terraform/aws calls
-// reuse the same file. The token value itself is never logged.
-func (c *client) webIdentityTokenFilePath() (string, error) {
-	if c.webIdentityTokenFile != "" {
-		return c.webIdentityTokenFile, nil
-	}
-
-	tokenFile, err := ioutil.TempFile("", "aws-web-identity-token-*")
-	if err != nil {
-		return "", err
-	}
-	defer tokenFile.Close()
-
-	if err := tokenFile.Chmod(0600); err != nil {
-		return "", err
-	}
-	if _, err := tokenFile.WriteString(c.model.WebIdentityToken); err != nil {
-		return "", err
-	}
-
-	c.webIdentityTokenFile = tokenFile.Name()
-	return c.webIdentityTokenFile, nil
 }


### PR DESCRIPTION
# Description

Reverts skyscrapers/terragrunt-resource#5, which added optional `web_identity_token` / `role_arn` source fields for the keyless-CI attempt. That work has been backed out (see the decision on skyscrapers/platform#2088): Concourse cannot cleanly carry a rotating token in a resource `source` without breaking version / `passed` tracking, so `admin-ci` will move to keyless via the Concourse replacement (skyscrapers/platform#1796) instead. The fields had no remaining consumer after skyscrapers/ci#230, so this removes the now-dead code path.

Pure revert of the squash-merged commit; no new behaviour.

# Related Issue

skyscrapers/platform#2088

# Checklist

- [x] My code has been tested:
  - [x] Locally (clean `git revert`, no conflicts; existing tests unaffected)
- [x] My code is ready to be applied.